### PR TITLE
Sync with an NTP server after connecting to Wifi

### DIFF
--- a/Lightbar.ino
+++ b/Lightbar.ino
@@ -5,6 +5,7 @@
 #include "radio.h"
 #include "lightbar.h"
 #include "mqtt.h"
+#include "time.h"
 
 WiFiClient wifiClient;
 Radio radio(RADIO_PIN_CE, RADIO_PIN_CSN);
@@ -33,6 +34,10 @@ void setupWifi()
 
   Serial.print("[WiFi] IP address: ");
   Serial.println(WiFi.localIP());
+
+  // init and get the time
+  configTime(GMT_OFFSET_SEC, DST_OFFSET_SEC, NTP_SERVER);
+  printLocalTime();
 }
 
 void setup()
@@ -72,4 +77,14 @@ void loop()
 
   mqtt.loop();
   radio.loop();
+}
+
+void printLocalTime()
+{
+  struct tm timeinfo;
+  if(!getLocalTime(&timeinfo)){
+    Serial.println("Failed to obtain time");
+    return;
+  }
+  Serial.println(&timeinfo, "[Time] %A, %B %d %Y %H:%M:%S");
 }

--- a/config-example.h
+++ b/config-example.h
@@ -73,3 +73,17 @@ constexpr SerialWithName REMOTES[] = {
 // later on. But if you want to have a specific name from the beginning or make it easier to identify the device,
 // you can set it here.
 #define HOME_ASSISTANT_DEVICE_NAME "Mi Computer Monitor Light Bar"
+
+/* -- Time ---------------------------------------------------------------------------------------------------- */
+// Syncs the system time with an NTP server. This helps some diplay the ESP32 in the clients list of some routers,
+// such as TP-Link Deco.
+
+// This is the NTP server
+#define NTP_SERVER "pool.ntp.org"
+
+// Your local timezone offset in seconds.
+// eg UTC+10 - 10 * 60 * 60
+#define GMT_OFFSET_SEC 0
+
+// The Daylight offset (in seconds). Set it to 3600 if your country observes Daylight saving time; otherwise, set it to 0.
+#define DST_OFFSET_SEC 0


### PR DESCRIPTION
Sync time with an NTP server after connecting successfully to wifi.
I added this step as without it, the ESP32 would not show up on my TP-Link Deco as a connected client, and I am a bit anal about having all my devices showing. 

I added appropriate options to `config-example.h` to allow users to set their own timezone offset, daylight savings offset and also another NTP server.